### PR TITLE
Fixed styling text-tile.

### DIFF
--- a/tipboard/tiles/text.js
+++ b/tipboard/tiles/text.js
@@ -11,11 +11,12 @@ function updateTileText(id, data, meta, tipboard) {
     var nodeWithText = containers[0];
     $(nodeWithText).html(data['text']);
 
+    var textSelector = '#' + id + ' .text-container';
     if (meta.font_size) {
-        $('.text-container').css("font-size", meta.font_size);
+        $(textSelector).css("font-size", meta.font_size);
     }
     if (meta.font_color) {
-        $('.text-container').css(
+        $(textSelector).css(
             "color", Tipboard.DisplayUtils.replaceFromPalette(meta.font_color)
         );
     }


### PR DESCRIPTION
There was a buggy selector for style applying in text-tile which took only
a text class instead of 'tile id followed by the class'