### PR TITLE
use wss:// on secure connection

### DIFF
--- a/tipboard/static/js/tipboard.js
+++ b/tipboard/static/js/tipboard.js
@@ -523,8 +523,11 @@ var renderersSwapper = new RenderersSwapper();
                 return; // the rest will be handled in onClose()
             }
             console.log("Initializing a new Web socket manager.");
+
+            var protocol = window.location.protocol === "https:" ? "wss://" : "ws://";
+
             this.websocket = new WebSocket(
-                "ws://" + window.location.host + "/communication/websocket"
+                protocol + window.location.host + "/communication/websocket"
             );
             this.websocket.onopen = function(evt) {
                 Tipboard.WebSocketManager.onOpen(evt);


### PR DESCRIPTION
improvement of pr [#45](https://github.com/allegro/tipboard/pull/45)

Use `wss://` only on secure connection. Because use `ws://` over https is blocked on Chrome and Firefox