### PR TITLE
Docs spellcheck.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ To verify your installation, launch this command::
 If you see the message ``Listening on port...`` instead of any errors, it means
 that installation was successful and you may now
 `configure <http://tipboard.readthedocs.org/en/latest/configuration.html>`_
-your newly installed Tipboard's instance. You may also point your favourite
+your newly installed Tipboard instance. You may also point your favorite
 web browser to ``http://localhost:7272`` to see the current state of your
 dashboard.
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -28,7 +28,7 @@ characters starting with ``API_KEY``, e.g.::
   API_KEY = 'e2c3275d0e1a4bc0da360dd225d74a43'
 
 If you can't see any such string, just add the key manually (it doesn't have
-to be as long and hard to memorise as the one above, though).
+to be as long and hard to memorize as the one above, though).
 
 .. note::
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -46,7 +46,7 @@ network interfaces, set ``host`` to ``0.0.0.0``).
 You can now point your web browser to ``http://localhost:7272`` - you should
 see a basic, empty layout with tiles in 2 lines of 4 columns each.
 
-Customising tile layout
+Customizing tile layout
 -----------------------
 
 As mentioned previously, the layout of tiles in a dashboard is defined by
@@ -92,7 +92,7 @@ where:
 
 .. describe:: row_X_of_Y
 
-   Defines a row hight; a sum of Xs should equal Y.
+   Defines a row height; a sum of Xs should equal Y.
 
 .. describe:: col_X_of_Y
 
@@ -181,7 +181,7 @@ divided into 3 columns)::
 
 ...its corresponding configuration file should look as follows (for brevity, I
 will present only the ``layout`` section, skipping the ``tile_template``,
-``title_id``, etc.)::
+``tile_id``, etc.)::
 
   layout:
       row_1_of_2:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -34,7 +34,7 @@ using ``nginx`` or ``apache``).
 .. note::
 
    Although configuration of reverse proxy is out of scope of this manual, we
-   would like to emphasise that Tipboard use Web Sockets – a relatively new
+   would like to emphasize that Tipboard uses Web Sockets – a relatively new
    mechanism – and thus you should ensure a server in a version that will
    support it (e.g. ``nginx`` >= 1.3.13 or ``apache2`` >= 2.4.6). By default
    Ubuntu 12.04 offers older versions – you may then use backports.

--- a/doc/tiles.rst
+++ b/doc/tiles.rst
@@ -8,7 +8,7 @@ name that corresponds with the tile name – e.g. with the ``pie_chart`` tile
 these are ``pie_chart.html``, ``pie_chart.css`` and ``pie_chart.js`` files
 respectively.
 
-Customising tiles
+Customizing tiles
 -----------------
 
 If you want to modify a tile (e.g. change a CSS attribute, which obviously
@@ -20,7 +20,7 @@ according to your needs.
 
 Files in your ``custom_tiles`` folder take precedence over those shipped by
 default with the application and thus you can easily replace desired elements
-(e.g. if you want to change the text colour, just copy and edit the ``.css``
+(e.g. if you want to change the text color, just copy and edit the ``.css``
 file – without touching ``.html`` and ``.js`` files). We plan to introduce a
 command simplifying this process in the future.
 
@@ -28,7 +28,7 @@ Color palette
 -------------
 
 Color palette used by Tipboard's tiles is defined as shown in the table below.
-To retain consistency, we strongly suggest sticking to them while customising
+To retain consistency, we strongly suggest sticking to them while customizing
 tiles.
 
 +-------------+---------------------+


### PR DESCRIPTION
The docs seem to favor American English throughout, so I corrected the British spellings.

Basically I just did a `aspell -l en_US check` on every file.

Also I corrected the reference to `title_id` which should of course be `tile_id`. This confused me for a second when I was first reading the docs :)

A very humble contribution, but I hope it helps, since we really like Tipboard at our company!